### PR TITLE
chore(flake/nixpkgs): `ba487dbc` -> `d69ab0d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741010256,
-        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "lastModified": 1741173522,
+        "narHash": "sha256-k7VSqvv0r1r53nUI/IfPHCppkUAddeXn843YlAC5DR0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "rev": "d69ab0d71b22fa1ce3dbeff666e6deb4917db049",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`e47bbc1f`](https://github.com/NixOS/nixpkgs/commit/e47bbc1f7cf0b40ad9e8ceb2f887c0fd12b9aa13) | `` firefox-{beta,devedition}-bin: 134.0b10 -> 137.0b1 ``                                          |
| [`bc5cd00d`](https://github.com/NixOS/nixpkgs/commit/bc5cd00d70528635ce1abf24a9f1075da8a4621a) | `` python312Packages.energyflow: disable failing tests on darwin ``                               |
| [`444f2c74`](https://github.com/NixOS/nixpkgs/commit/444f2c742b7ac60ee5c6b51b849c651157c0f9e4) | `` python313Packages.django-js-asset: 3.1 -> 3.1.2 ``                                             |
| [`a3cd526f`](https://github.com/NixOS/nixpkgs/commit/a3cd526f08839bd963e7d106b7869694b0579a94) | `` ncdc: 1.24.1 -> 1.25 ``                                                                        |
| [`321281bb`](https://github.com/NixOS/nixpkgs/commit/321281bb0c94008ae351aca2a2ea5ac1d0f7b428) | `` nesting: init at 0.3.0 ``                                                                      |
| [`91943aaa`](https://github.com/NixOS/nixpkgs/commit/91943aaa5ff38714a266f2363a3602472418a09d) | `` vimPlugins.orgmode: fix tree-sitter-org error ``                                               |
| [`d073485e`](https://github.com/NixOS/nixpkgs/commit/d073485e69d13b93c92f6112c2b0a08f9ddac8a4) | `` gallia: relax httpx and msgspec ``                                                             |
| [`eb833beb`](https://github.com/NixOS/nixpkgs/commit/eb833bebe3779e3a4f058c303a80a8bdf70491ae) | `` bacon: install shell completions ``                                                            |
| [`d325772e`](https://github.com/NixOS/nixpkgs/commit/d325772e9e7213ee7e003dba641e664899c7b790) | `` pkgs: write down that meta should be last ``                                                   |
| [`9b301c5b`](https://github.com/NixOS/nixpkgs/commit/9b301c5b1ba08b022ef3caf5443957b319ccf5f4) | `` wtfutil: fix wtfutil --version ``                                                              |
| [`f6a0f156`](https://github.com/NixOS/nixpkgs/commit/f6a0f156dfcaca1bdf6de46907a0c813e3c277de) | `` wtfutil: add xiaoxiangmoe as maintainer ``                                                     |
| [`6cbe4bd3`](https://github.com/NixOS/nixpkgs/commit/6cbe4bd3ade9024df540cfb5dcab537773223fe9) | `` wtfutil: rename wtf to wtfutil ``                                                              |
| [`293f9754`](https://github.com/NixOS/nixpkgs/commit/293f97544cc49cc0a8308aeeb1574e8c6719d408) | `` tor-browser: 14.0.6 -> 14.0.7 ``                                                               |
| [`783dff1c`](https://github.com/NixOS/nixpkgs/commit/783dff1c6f8e2da58a93408fb1f5f050199a8cc8) | `` monado: set VIT_SYSTEM_LIBRARY_PATH so that libbasalt.so can be found ``                       |
| [`b7fb205e`](https://github.com/NixOS/nixpkgs/commit/b7fb205edeabae7c8e9be21cfbb53233b2ab7c39) | `` udpspeeder: init at 20230206.0 ``                                                              |
| [`3c7045c2`](https://github.com/NixOS/nixpkgs/commit/3c7045c28ab1523ad8e66e91e71adacc2c4d2597) | `` openttd: Fix packaging issues ``                                                               |
| [`ae785690`](https://github.com/NixOS/nixpkgs/commit/ae7856907e30056e948c28757b311b2a7e61d1a5) | `` haproxy: 3.1.4 -> 3.1.5 ``                                                                     |
| [`7bffbf3c`](https://github.com/NixOS/nixpkgs/commit/7bffbf3c4c89d1b7f240fa606056b6b0fd4a275e) | `` nixos/nats: add option validateConfig (#387048) ``                                             |
| [`a7bb3d66`](https://github.com/NixOS/nixpkgs/commit/a7bb3d664844dd9b782f1fb0cced3506a1973c5b) | `` libgeotiff: 1.7.3 -> 1.7.4 ``                                                                  |
| [`48a038e7`](https://github.com/NixOS/nixpkgs/commit/48a038e76ef1bac4c659f592dd952d074d9c391f) | `` erigon: 2.61.1 -> 2.61.2 ``                                                                    |
| [`dd87a30c`](https://github.com/NixOS/nixpkgs/commit/dd87a30c58b960e331b5b0fb819e9dbd865ee0a2) | `` nixos/tests/glitchtip: init ``                                                                 |
| [`5da710d2`](https://github.com/NixOS/nixpkgs/commit/5da710d274e73a60413bb8a97e0b5dc0b003e179) | `` nixos/glitchtip: init module ``                                                                |
| [`f4381af0`](https://github.com/NixOS/nixpkgs/commit/f4381af0361816f3831c943918c67c1bad59efcf) | `` glitchtip: init at 4.2.5 ``                                                                    |
| [`b208c22b`](https://github.com/NixOS/nixpkgs/commit/b208c22be6a3518c6d9da191c12c459f071d2718) | `` python312Packages.lightning-utilities: 0.13.0 -> 0.13.1 ``                                     |
| [`1afb093e`](https://github.com/NixOS/nixpkgs/commit/1afb093ed66dcdd354ed1518ccbf46d4ea79503d) | `` phpPackages.box: 4.6.2 -> 4.6.6, fix `installCheck` ``                                         |
| [`c0999f43`](https://github.com/NixOS/nixpkgs/commit/c0999f435e35bbee0968af460bc4db84bf9f6b11) | `` phpdocumentor: 3.6.0 -> 3.7.1 ``                                                               |
| [`64b24665`](https://github.com/NixOS/nixpkgs/commit/64b246657df86cde5a8ff8f713fbd3721cb6b598) | `` build-support/php: enable support for `dontCheckForBrokenSymlinks` set to `true` by default `` |
| [`489ac481`](https://github.com/NixOS/nixpkgs/commit/489ac4817f5ed4101d9865a551622ce80ec87a7f) | `` build-support/php: refactor build scripts ``                                                   |
| [`1de8208e`](https://github.com/NixOS/nixpkgs/commit/1de8208e4a542d10b5fdfd52c35f6f2221f2df24) | `` laravel: update hash ``                                                                        |
| [`6e8e6c41`](https://github.com/NixOS/nixpkgs/commit/6e8e6c413d7a189f85d3319b9e0ade14296eda53) | `` robo: update hash, add `installCheck` ``                                                       |
| [`66d96a76`](https://github.com/NixOS/nixpkgs/commit/66d96a76b590edf9fd4f749ad9ad644f762a748e) | `` phel: update hash, add `installCheck` ``                                                       |
| [`e7304f58`](https://github.com/NixOS/nixpkgs/commit/e7304f587a2d632839cb7481a9965f7309bc08d9) | `` paratest: 7.6.0 -> 7.8.2 ``                                                                    |
| [`7e70611b`](https://github.com/NixOS/nixpkgs/commit/7e70611b1ed00f61e2ea8da5a6f871ec2a06f6ea) | `` phpPackages.phpinsights: update hash, add `installCheck` ``                                    |
| [`fe92c2a6`](https://github.com/NixOS/nixpkgs/commit/fe92c2a63a461232b11aa7ec04098958a156c459) | `` domoticz: modernize derivation ``                                                              |
| [`b6044982`](https://github.com/NixOS/nixpkgs/commit/b6044982352ea07f05907febbb63beefda2bd41a) | `` domoticz: fix build on GCC 14, Boost 1.87 ``                                                   |
| [`3b33c514`](https://github.com/NixOS/nixpkgs/commit/3b33c51443fcfcf5479c9e36d69f1e430bfd00bb) | `` vimPlugins.mini-test: build from lua package ``                                                |
| [`4063f1e2`](https://github.com/NixOS/nixpkgs/commit/4063f1e23d12eefa693e58b4558bd9c29870eed5) | `` vscode-extensions.ms-toolsai.jupyter: 2025.1.0 -> 2025.2.0 ``                                  |
| [`59980805`](https://github.com/NixOS/nixpkgs/commit/599808056ec5e6d4ab419c9bc70a954a4eb1fefa) | `` tailscale: 1.80.2 -> 1.80.3 ``                                                                 |
| [`ee164ade`](https://github.com/NixOS/nixpkgs/commit/ee164ade862f2ff264f72fcf57b7a3acd9a8f69f) | `` saunafs: 4.7.0 -> 4.8.0 ``                                                                     |
| [`23df782d`](https://github.com/NixOS/nixpkgs/commit/23df782d524dfccb208364854b9470c2e5d48a1e) | `` simdutf: 6.2.0 -> 6.2.1 ``                                                                     |
| [`092bc3e6`](https://github.com/NixOS/nixpkgs/commit/092bc3e66ff2b6db4f94bd7bc6d88486346291f1) | `` firefox-bin: release_sources: add linux-aarch64 ``                                             |
| [`e5aa62a4`](https://github.com/NixOS/nixpkgs/commit/e5aa62a44bbcdae925d75c9f60e724528aab3048) | `` firefox-bin: update.nix: also update linux-aarch64 now ``                                      |
| [`9b617fcc`](https://github.com/NixOS/nixpkgs/commit/9b617fcc72effb78b42278845a4c3a7957495a7e) | `` firefox-bin: add linux-aarch64 to mozillaPlatforms ``                                          |
| [`5c22fc73`](https://github.com/NixOS/nixpkgs/commit/5c22fc7391ce30f87e9aa2671f13b427e691c69c) | `` fish-lsp: 1.0.8-1 -> 1.0.8-4 ``                                                                |
| [`79d2e9ac`](https://github.com/NixOS/nixpkgs/commit/79d2e9ac71954e2c6fb29ddec7b026170ca15273) | `` upcloud-cli: 3.14.0 -> 3.15.0 ``                                                               |
| [`172e551c`](https://github.com/NixOS/nixpkgs/commit/172e551c5ae7dd4259d6bc745dc88fbeefd0b0a3) | `` vscode-extensions.streetsidesoftware.code-spell-checker: 4.0.21 -> 4.0.41 ``                   |
| [`45782a83`](https://github.com/NixOS/nixpkgs/commit/45782a83b73a3617b695968323d1737a1ac59f47) | `` nixosTests.hddfancontrol: remove ``                                                            |
| [`6a791193`](https://github.com/NixOS/nixpkgs/commit/6a791193b65a25c232f88ed408869d585d95d053) | `` nixos/hddfancontrol: support v2 argument format ``                                             |
| [`654972b7`](https://github.com/NixOS/nixpkgs/commit/654972b7328bb2ca6c20d12baec4c715da865394) | `` teams: Update Nix formatting team ``                                                           |
| [`17ce56fb`](https://github.com/NixOS/nixpkgs/commit/17ce56fbf034491cf0c542f1cff84d4745d19a3d) | `` vscode-extensions.ms-python.python: 2025.1.2025021102 -> 2025.1.2025022501 ``                  |
| [`fe274fe5`](https://github.com/NixOS/nixpkgs/commit/fe274fe5cda9cd3e1b277dbc766a9da2dc578a7c) | `` adguardhome: 0.107.56 -> 0.107.57 ``                                                           |
| [`ed11e43e`](https://github.com/NixOS/nixpkgs/commit/ed11e43e3db3dadfe7d99f81dcfb551344abd358) | `` vscode-extensions.vscodevim.vim: 1.26.1 -> 1.29.0 ``                                           |
| [`5d81e7cc`](https://github.com/NixOS/nixpkgs/commit/5d81e7cc681b8e3cb9cbbd6dbd4039bc2140e41f) | `` vscode-extensions.asciidoctor.asciidoctor-vscode: 2.8.9 -> 3.4.2 ``                            |
| [`2c0585fc`](https://github.com/NixOS/nixpkgs/commit/2c0585fc38143e50e06d345bd2262b640b8a477f) | `` vscode-extensions.llvm-vs-code-extensions.vscode-clangd: 0.1.24 -> 0.1.33 ``                   |
| [`aa6af5df`](https://github.com/NixOS/nixpkgs/commit/aa6af5dff355b1a8e0d3ff46eacadd0a88e7f305) | `` vscode-extensions.eamodio.gitlens: 16.0.5 -> 16.3.2 ``                                         |
| [`aa8fe453`](https://github.com/NixOS/nixpkgs/commit/aa8fe453981f38a286025e2c780ce15c5c0810a4) | `` hddfancontrol: 1.5.1->2.0.1 ``                                                                 |
| [`932c7611`](https://github.com/NixOS/nixpkgs/commit/932c76111ec08b523c40208765279f795b87d837) | `` cargo-clean-recursive: init at 1.0.0 ``                                                        |
| [`2866687c`](https://github.com/NixOS/nixpkgs/commit/2866687c1941f649becf1a19b25fd1d20f8dd687) | `` maintainers: added qubic ``                                                                    |
| [`43b4c23b`](https://github.com/NixOS/nixpkgs/commit/43b4c23be4a2bcaa1ba06e179762d55c4cecfa96) | `` qt5.qtwebengine: fix missing GN dependency ``                                                  |
| [`8cfff8cb`](https://github.com/NixOS/nixpkgs/commit/8cfff8cba9ce0faf859a256f2b0dd503ad7fa1de) | `` electron-bin: don't wrap inside libexec ``                                                     |
| [`afc26134`](https://github.com/NixOS/nixpkgs/commit/afc2613411fb255b89d80d152c7c0090c1873748) | `` bs-manager: set ELECTRON_FORCE_IS_PACKAGED ``                                                  |
| [`d0dfd3b3`](https://github.com/NixOS/nixpkgs/commit/d0dfd3b3f9282d791d945566f1738c90c5b3060d) | `` python312Packages.plotpy: skip crashing tests on darwin ``                                     |
| [`d37a6a67`](https://github.com/NixOS/nixpkgs/commit/d37a6a671f9314e043c6f7c2dcbf88ba21d7b76f) | `` go-passbolt-cli: 0.3.1 -> 0.3.2 ``                                                             |
| [`c2fd31d7`](https://github.com/NixOS/nixpkgs/commit/c2fd31d740d2077076554c312a0d9003a1153e88) | `` fingerprintx: 1.1.14 -> 1.1.15 ``                                                              |
| [`27a33c4f`](https://github.com/NixOS/nixpkgs/commit/27a33c4fe1c47f7605dc6dd7df911779c0a4e414) | `` ente-desktop: fix tray icon (#387042) ``                                                       |
| [`9a18fdb0`](https://github.com/NixOS/nixpkgs/commit/9a18fdb009f23e3d547a9a2a33f4ca83a5886233) | `` signalbackup-tools: 20250303-2 -> 20250304-1 ``                                                |
| [`81b5c727`](https://github.com/NixOS/nixpkgs/commit/81b5c727ae45e651aa922c8801d58d4782d31f28) | `` python3Packages.uwsgi-chunked: init at 0.1.8 ``                                                |
| [`e82f1f11`](https://github.com/NixOS/nixpkgs/commit/e82f1f110a6b57a1dfc95d753438105d5f737590) | `` python3Packages.symbolic: init at 10.2.1 ``                                                    |
| [`874a6d7d`](https://github.com/NixOS/nixpkgs/commit/874a6d7d366380bee5c87bf98b90ff6fad7a718c) | `` phpPackages.psysh: update hash, add `installCheck` ``                                          |
| [`47f6b52a`](https://github.com/NixOS/nixpkgs/commit/47f6b52a456670c292d42971f42f430137b6307a) | `` phpPackages.phing: update hash, add `installCheck` ``                                          |
| [`2e4faebd`](https://github.com/NixOS/nixpkgs/commit/2e4faebd4d9e4dee920a2c884e0d37cd44a5625e) | `` deployer: 7.4.0 -> 7.5.12-unstable-2025-03-02 ``                                               |
| [`a3c502b6`](https://github.com/NixOS/nixpkgs/commit/a3c502b6c9957bffddce57e9c301682d56c0dc41) | `` python3Packages.django-sql-utils: init at 0.7.0 ``                                             |
| [`07bcf3e9`](https://github.com/NixOS/nixpkgs/commit/07bcf3e909f5db0dcef5bd31885aab3fdeae1d7b) | `` pkgs-lib.formats.xml: Fix withHeader parameter ``                                              |
| [`7398b0d3`](https://github.com/NixOS/nixpkgs/commit/7398b0d38ddc7afab69c3abd09fbfb6b1fd36664) | `` photofield: 0.17.1 -> 0.18.0 ``                                                                |
| [`ef01b05b`](https://github.com/NixOS/nixpkgs/commit/ef01b05b9eb6c3dcc167670bb483aa79ecd6ca61) | `` firefox-esr-128-unwrapped: 128.7.0esr -> 128.8.0esr ``                                         |
| [`8645a5b3`](https://github.com/NixOS/nixpkgs/commit/8645a5b39b3bb32e8291ab669ae6ae19bd2c5e6a) | `` firefox-bin-unwrapped: 135.0.1 -> 136.0 ``                                                     |
| [`e1a870db`](https://github.com/NixOS/nixpkgs/commit/e1a870dbedf26e358f70530bcbd53a2761bdb41f) | `` firefox-unwrapped: 135.0.1 -> 136.0 ``                                                         |
| [`f69df6fd`](https://github.com/NixOS/nixpkgs/commit/f69df6fd850770a7e0265dc2ea1073d90429af74) | `` renderdoc: 1.36 -> 1.37 ``                                                                     |
| [`04e9a8e5`](https://github.com/NixOS/nixpkgs/commit/04e9a8e5ba8bd5edf8b0014ff3bf67682f0cdfcb) | `` python312Packages.guidata: skip crashing tests on darwin ``                                    |
| [`c5c6c183`](https://github.com/NixOS/nixpkgs/commit/c5c6c1830640f5273b9b4e780bfc51c7860be15d) | `` python312Packages.lightning-utilities: 0.12.0 -> 0.13.0 ``                                     |
| [`5cdf2741`](https://github.com/NixOS/nixpkgs/commit/5cdf27419298b23166d956881855a187effea86a) | `` python312Packages.shiny: 1.2.1 -> 1.3.0 ``                                                     |
| [`c2859e8a`](https://github.com/NixOS/nixpkgs/commit/c2859e8a7194936b936d1dcf097057920ae34f1a) | `` vscode-extensions.jnoortheen.nix-ide: 0.3.5 -> 0.4.12 ``                                       |
| [`4ccec684`](https://github.com/NixOS/nixpkgs/commit/4ccec684a6f5096e56918758a85a794ad0564157) | `` kiwix-tools: 3.7.0 -> 3.7.0-unstable-2024-12-21 to fix build against kiwix-14.0 ``             |
| [`3523d821`](https://github.com/NixOS/nixpkgs/commit/3523d821b5f0cd49d2c70e0f87a454206fa28028) | `` vscode-extensions.asvetliakov.vscode-neovim: 1.18.14 -> 1.18.17 ``                             |
| [`85bde303`](https://github.com/NixOS/nixpkgs/commit/85bde3039f30158d8a08f4a5b4de15eaac5192ad) | `` vscode-extensions.arrterian.nix-env-selector: 1.0.10 -> 1.0.12 ``                              |
| [`bad44b18`](https://github.com/NixOS/nixpkgs/commit/bad44b18be845366bb727b8e36cab55deeafbb63) | `` solanum: 0-unstable-2025-01-29 -> 0-unstable-2025-02-25 ``                                     |
| [`43b6845b`](https://github.com/NixOS/nixpkgs/commit/43b6845ba7ab4ea92e8b044c150c4e6b5bc1f9d7) | `` svg2pdf: 0.12.0 -> 0.13.0 ``                                                                   |
| [`eb555bb4`](https://github.com/NixOS/nixpkgs/commit/eb555bb4ad911d3624c62b8bba1475a2f72d8669) | `` python313Packages.torch-geometric: disable tests failing on python 3.13 ``                     |
| [`036500eb`](https://github.com/NixOS/nixpkgs/commit/036500eb05f6081bddd66c415e7f2214228b2f15) | `` klipper: 0.12.0-unstable-2025-02-02 -> 0.12.0-unstable-2025-02-28 ``                           |
| [`cc3b4b39`](https://github.com/NixOS/nixpkgs/commit/cc3b4b394ce84bcdcc5b40a430dfe4884ab9eba0) | `` cinny-desktop: 4.3.2 -> 4.5.0 ``                                                               |
| [`edf89ef1`](https://github.com/NixOS/nixpkgs/commit/edf89ef18f2e01db45747b5b88ab246e32216a59) | `` cinny: 4.3.2 -> 4.5.0 ``                                                                       |
| [`7dc6352e`](https://github.com/NixOS/nixpkgs/commit/7dc6352e3a761becd9c535c7c1e37e3fe53fb0d4) | `` zx: 8.3.0 -> 8.4.0 ``                                                                          |
| [`b7607566`](https://github.com/NixOS/nixpkgs/commit/b7607566baa4344277d946c3e8f4eeb79d3204ab) | `` pikchr: 0-unstable-2024-02-12 -> 0-unstable-2025-02-28 ``                                      |
| [`3b15e29e`](https://github.com/NixOS/nixpkgs/commit/3b15e29ea4857444f26083fed4678a5c41d55649) | `` ladybird: 0-unstable-2025-02-04 -> 0-unstable-2025-03-04 ``                                    |
| [`30e85bdf`](https://github.com/NixOS/nixpkgs/commit/30e85bdff4e757ff95bd507d53f8e8e5eca4438b) | `` python312Packages.mmengine: 0.10.6 -> 0.10.7 ``                                                |
| [`91be6b3c`](https://github.com/NixOS/nixpkgs/commit/91be6b3c8ff6a508a611ff17dc3886a18940c8b5) | `` nixosTests.lomiri-system-settings: Switch to runTest ``                                        |
| [`6c0e95a2`](https://github.com/NixOS/nixpkgs/commit/6c0e95a219d0853e47c702082ddfe69e1b17e1d3) | `` ArchiSteamFarm: 6.1.2.3 -> 6.1.3.3 ``                                                          |
| [`c1f0ad5b`](https://github.com/NixOS/nixpkgs/commit/c1f0ad5b9566f482996ac375301d15157ea3498b) | `` python312Packages.deal: 4.24.4 -> 4.24.5 ``                                                    |
| [`e0ac5194`](https://github.com/NixOS/nixpkgs/commit/e0ac5194ab67c0b7230957d67ecdd6b3e64fadf6) | `` nixos/osquery: revert test for database_path ``                                                |
| [`4422dc0c`](https://github.com/NixOS/nixpkgs/commit/4422dc0c6270bdc569f1aa3aef750edc3ab11c4c) | `` grafana-alloy: 1.6.1 -> 1.7.1 ``                                                               |
| [`f5167764`](https://github.com/NixOS/nixpkgs/commit/f5167764fc185b5b9ea65d9ab3970797b9582ba1) | `` tradingview: 2.9.3 -> 2.9.6 ``                                                                 |
| [`6e23095d`](https://github.com/NixOS/nixpkgs/commit/6e23095df7939ad63d739a1899a324d640e9d000) | `` lightningstream: init at 0.4.3 ``                                                              |
| [`33312291`](https://github.com/NixOS/nixpkgs/commit/333122915b411280b1dda3eb655946ba596ccbf9) | `` grafana-alloy: fix updateScript selecting the wrong tag ``                                     |
| [`e4b3e445`](https://github.com/NixOS/nixpkgs/commit/e4b3e4454d679aaadc25efb4eb8b9b4db192854c) | `` skypeforlinux: 8.136.0.203 -> 8.137.0.425 ``                                                   |
| [`c5cd965e`](https://github.com/NixOS/nixpkgs/commit/c5cd965e341bb5d09ad0a75004c11ee40fb8ff3f) | `` python312Packages.skytemple-ssb-emulator: 1.8.0 -> 1.8.1 ``                                    |
| [`26549c93`](https://github.com/NixOS/nixpkgs/commit/26549c932027944b5433636a4442ee1c15ae6641) | `` python312Packages.optree: 0.14.0 -> 0.14.1 ``                                                  |