### PR TITLE
chore(flake/nixpkgs): `5e5402ec` -> `52faf482`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`b9cfe386`](https://github.com/NixOS/nixpkgs/commit/b9cfe386b47cdbab12ed339b6e50c8a5d4ed72d3) | `` immich: 1.129.0 -> 1.130.3 ``                                                                                                                                                              |
| [`1d526500`](https://github.com/NixOS/nixpkgs/commit/1d526500e4d7dba85a406606f96d15088e20e4fc) | `` phpactor: 2025.02.21.0 -> 2025.03.28.0 ``                                                                                                                                                  |
| [`90a1eaf2`](https://github.com/NixOS/nixpkgs/commit/90a1eaf2475e3fb53d8dbf46b27ac9b410479965) | `` wait4x: fix repository reference (#394374) ``                                                                                                                                              |
| [`ead53ee8`](https://github.com/NixOS/nixpkgs/commit/ead53ee8f0d136262466ada022e37317146d5fab) | `` root: 6.34.04 -> 6.34.06 (#393976) ``                                                                                                                                                      |
| [`19e40fad`](https://github.com/NixOS/nixpkgs/commit/19e40fad1ed18701366b61288a226cd42d76ed1f) | `` strip-ansi: init at 0.1.0-unstable-2024-09-01 ``                                                                                                                                           |
| [`dcb18343`](https://github.com/NixOS/nixpkgs/commit/dcb18343ecf84137b3226a4597677ba4fca98ba1) | `` vimPlugins.lze: 0.9.1 -> 0.11.0 ``                                                                                                                                                         |
| [`7e3a6179`](https://github.com/NixOS/nixpkgs/commit/7e3a6179236a16d4a80e6d84eebf5b4005da249b) | `` livepeer: 0.8.3 -> 0.8.4 ``                                                                                                                                                                |
| [`238c8534`](https://github.com/NixOS/nixpkgs/commit/238c85347143cce6080bd02ea7d0b28436a4a75f) | `` python3Packages.textnets: 0.9.5 -> 0.10.3 ``                                                                                                                                               |
| [`48e6184d`](https://github.com/NixOS/nixpkgs/commit/48e6184ddf9708c76aa97525589fbd941d3d94a1) | `` nixosTests.dolibarr: migrate to runTest ``                                                                                                                                                 |
| [`c965960d`](https://github.com/NixOS/nixpkgs/commit/c965960d60791d17c4269eeb365323d4ba04a566) | `` maintainers/team-list: add novmar to jitsi team ``                                                                                                                                         |
| [`65e34219`](https://github.com/NixOS/nixpkgs/commit/65e342192f244a50a1f2e902a2a672eef0c10894) | `` vscode-extensions.ziglang.vscode-zig: 0.6.6 -> 0.6.7 ``                                                                                                                                    |
| [`f81cfd23`](https://github.com/NixOS/nixpkgs/commit/f81cfd230023b17a6c64ee72cf41276a57848aa3) | `` vscode-extensions.vscode-icons-team.vscode-icons: 12.11.0 -> 12.12.0 ``                                                                                                                    |
| [`75c899cc`](https://github.com/NixOS/nixpkgs/commit/75c899cc3239d997f1ecdb9145ab47d16647d751) | `` vscode-extensions.visualstudiotoolsforunity.vstuc: 1.1.0 -> 1.1.1 ``                                                                                                                       |
| [`0ad23d8d`](https://github.com/NixOS/nixpkgs/commit/0ad23d8d7fb506bdb7bea3c8cb394f522a80aa66) | `` vscode-extensions.tabnine.tabnine-vscode: 3.247.0 -> 3.249.0 ``                                                                                                                            |
| [`37e62331`](https://github.com/NixOS/nixpkgs/commit/37e62331241f4a0155b013a1e75c7d47d8f3912f) | `` vscode-extensions.stylelint.vscode-stylelint: 1.4.0 -> 1.5.0 ``                                                                                                                            |
| [`871c183d`](https://github.com/NixOS/nixpkgs/commit/871c183d5b7a63c5bb47d53adad7bd01424f162a) | `` vscode-extensions.shopify.ruby-lsp: 0.9.12 -> 0.9.13 ``                                                                                                                                    |
| [`3efee126`](https://github.com/NixOS/nixpkgs/commit/3efee1269f503897523ef8cd408ae500babd87a5) | `` vscode-extensions.saoudrizwan.claude-dev: 3.8.3 -> 3.8.4 ``                                                                                                                                |
| [`7d9464e0`](https://github.com/NixOS/nixpkgs/commit/7d9464e0de8699db2fc093a799bab600560b0898) | `` vscode-extensions.naumovs.color-highlight: 2.6.0 -> 2.8.0 ``                                                                                                                               |
| [`1e0be03f`](https://github.com/NixOS/nixpkgs/commit/1e0be03fb6e447b8c1bb9db4585ed1335933ba75) | `` nixosTests.nginx-moreheaders: migrate to runTest ``                                                                                                                                        |
| [`9a3d7473`](https://github.com/NixOS/nixpkgs/commit/9a3d7473c4815f5d0189263e983d0eef0639c795) | `` nixosTests.nginx-modsecurity: migrate to runTest ``                                                                                                                                        |
| [`af2b019d`](https://github.com/NixOS/nixpkgs/commit/af2b019d25c3712ade22985a1741354aeb3b12eb) | `` nixosTests.nginx-mime: migrate to runTest ``                                                                                                                                               |
| [`69df9598`](https://github.com/NixOS/nixpkgs/commit/69df9598cb29bcef8903ba0ba083b01212a5396d) | `` nixosTests.nginx-globalredirect: migrate to runTest ``                                                                                                                                     |
| [`8638fa37`](https://github.com/NixOS/nixpkgs/commit/8638fa379f9965190c6112537de8381fe468fb4d) | `` nixosTests.nginx-etag-compression: migrate to runTest ``                                                                                                                                   |
| [`a186de0f`](https://github.com/NixOS/nixpkgs/commit/a186de0fa1ce0d45cf92d588653e801bcce0cd04) | `` nixosTests.nginx-etag: migrate to runTest ``                                                                                                                                               |
| [`58c351d0`](https://github.com/NixOS/nixpkgs/commit/58c351d04838d59c0d2cfd375dc3ffc2cde1eda2) | `` vscode-extensions.ms-vscode.anycode: 0.0.73 -> 0.0.74 ``                                                                                                                                   |
| [`5bc25565`](https://github.com/NixOS/nixpkgs/commit/5bc25565a08284fc850150b87fe5fe74f5e74d25) | `` vscode-extensions.ms-pyright.pyright: 1.1.397 -> 1.1.398 ``                                                                                                                                |
| [`bf5afb59`](https://github.com/NixOS/nixpkgs/commit/bf5afb5961c706042c5bcaec4f1efca868911f22) | `` vscode-extensions.mishkinf.goto-next-previous-member: 0.0.6 -> 0.0.10 ``                                                                                                                   |
| [`8624a876`](https://github.com/NixOS/nixpkgs/commit/8624a8760e5aa3487313e47ec6260f4bd45fa335) | `` vscode-extensions.james-yu.latex-workshop: 10.8.0 -> 10.9.0 ``                                                                                                                             |
| [`307dae83`](https://github.com/NixOS/nixpkgs/commit/307dae83eb18f31dac5154cc426f3823486a5a24) | `` vscode-extensions.graphql.vscode-graphql-syntax: 1.3.6 -> 1.3.8 ``                                                                                                                         |
| [`a887d964`](https://github.com/NixOS/nixpkgs/commit/a887d9644d5de573fa17083cc9305c1b97c46445) | `` vscode-extensions.gleam.gleam: 2.3.0 -> 2.11.1 ``                                                                                                                                          |
| [`caa0cf5e`](https://github.com/NixOS/nixpkgs/commit/caa0cf5e08f28cfe902f85b5f4577036cfdaa481) | `` vscode-extensions.github.copilot: 1.292.0 -> 1.293.0 ``                                                                                                                                    |
| [`67bc187d`](https://github.com/NixOS/nixpkgs/commit/67bc187d11c1c1fdfab722c0d1d121ac3f65010f) | `` vscode-extensions.genieai.chatgpt-vscode: 0.0.8 -> 0.0.13 ``                                                                                                                               |
| [`4aacc16b`](https://github.com/NixOS/nixpkgs/commit/4aacc16ba9e29287d3b8a39f5165aad1009fd0f7) | `` vscode-extensions.geequlim.godot-tools: 2.3.0 -> 2.5.1 ``                                                                                                                                  |
| [`0104c4c6`](https://github.com/NixOS/nixpkgs/commit/0104c4c61a7b3aab0b9b233ac1ddff4b144dfd6d) | `` vscode-extensions.foam.foam-vscode: 0.26.8 -> 0.26.10 ``                                                                                                                                   |
| [`e14c0eea`](https://github.com/NixOS/nixpkgs/commit/e14c0eeaa96e8d475840b9aa0df949398865ea9c) | `` vscode-extensions.fabiospampinato.vscode-open-in-github: 2.3.0 -> 2.3.1 ``                                                                                                                 |
| [`5f6e89c6`](https://github.com/NixOS/nixpkgs/commit/5f6e89c6fc48ef495e637e24597ed22b09d3113b) | `` vscode-extensions.elmtooling.elm-ls-vscode: 2.6.0 -> 2.8.0 ``                                                                                                                              |
| [`b9d0e2e2`](https://github.com/NixOS/nixpkgs/commit/b9d0e2e23d809316f7fb57facc87ab172469946b) | `` vscode-extensions.devsense.profiler-php-vscode: 1.41.14332 -> 1.57.17031 ``                                                                                                                |
| [`0ca5efcb`](https://github.com/NixOS/nixpkgs/commit/0ca5efcb65ae6982a2e77d27850e2de88b738f68) | `` vscode-extensions.catppuccin.catppuccin-vsc: 3.16.1 -> 3.17.0 ``                                                                                                                           |
| [`4b2884b1`](https://github.com/NixOS/nixpkgs/commit/4b2884b1f80a907dd849a17350b048559bfd3805) | `` vscode-extensions.bradlc.vscode-tailwindcss: 0.14.11 -> 0.14.12 ``                                                                                                                         |
| [`ccdbfe5c`](https://github.com/NixOS/nixpkgs/commit/ccdbfe5c8dea2412e465089be15f08e02c7b22fd) | `` vscode-extensions.bmalehorn.vscode-fish: 1.0.38 -> 1.0.39 ``                                                                                                                               |
| [`3fb970e3`](https://github.com/NixOS/nixpkgs/commit/3fb970e31853b50b547baaee2c15c5159b423616) | `` vscode-extensions.bazelbuild.vscode-bazel: 0.10.0 -> 0.11.0 ``                                                                                                                             |
| [`80f66368`](https://github.com/NixOS/nixpkgs/commit/80f663686d15c32464a9306bb006a5a041af28b9) | `` vscode-extensions.angular.ng-template: 19.2.1 -> 19.2.2 ``                                                                                                                                 |
| [`fa514139`](https://github.com/NixOS/nixpkgs/commit/fa5141395f7866b91a4aeacfcdbe168ac9bb571a) | `` nixosTests.nginx-auth: migrate to runTest ``                                                                                                                                               |
| [`389f2fb9`](https://github.com/NixOS/nixpkgs/commit/389f2fb908916244829381b618e4e699f410a5c5) | `` nixosTests.nginx: migrate to runTest ``                                                                                                                                                    |
| [`f999c90e`](https://github.com/NixOS/nixpkgs/commit/f999c90e8bcc997ececf1de1c6ce11ab154fc791) | `` python313Packages.nhc: 0.4.10 -> 0.4.11 ``                                                                                                                                                 |
| [`5ae8e39e`](https://github.com/NixOS/nixpkgs/commit/5ae8e39ef773696126f9e9cd6f912299596d2b9c) | `` nixosTests.wiki-js: migrate to runTest ``                                                                                                                                                  |
| [`1f1879a3`](https://github.com/NixOS/nixpkgs/commit/1f1879a36420b7cae28bb29d6b6ae1f4adb0c849) | `` libdeltachat: 1.157.3 -> 1.158.0 ``                                                                                                                                                        |
| [`e6dd7d66`](https://github.com/NixOS/nixpkgs/commit/e6dd7d6641038fd6e3fe57057d4bc5bde5bf04ff) | `` nixosTests.icingaweb2: migrate to runTest ``                                                                                                                                               |
| [`e90d9be0`](https://github.com/NixOS/nixpkgs/commit/e90d9be0a3c7f3adc051bd1fb31b3487a1f2be84) | `` nixosTests.monica: migrate to runTest ``                                                                                                                                                   |
| [`ee495663`](https://github.com/NixOS/nixpkgs/commit/ee495663d0ec679788b45fa4114436bf4c753b47) | `` osquery: fix update script ``                                                                                                                                                              |
| [`5019e6e3`](https://github.com/NixOS/nixpkgs/commit/5019e6e3ac061104b5f75762c44bc941e1aad191) | `` python312Packages.coiled: 1.86.0 -> 1.90.2 ``                                                                                                                                              |
| [`0bf5b65b`](https://github.com/NixOS/nixpkgs/commit/0bf5b65bb420de92edf41fdf882ca8c2b3a66a32) | `` freetube: 0.23.2 -> 0.23.3 ``                                                                                                                                                              |
| [`69c26f33`](https://github.com/NixOS/nixpkgs/commit/69c26f338b1863dfc45819f693abfcb1de582c2d) | `` monica: pin php version to 8.3 ``                                                                                                                                                          |
| [`ab3b601d`](https://github.com/NixOS/nixpkgs/commit/ab3b601d8846be3d96c18ebb0be53dd13bcd9a5c) | `` rutorrent: pin php version to 8.2 ``                                                                                                                                                       |
| [`375292a2`](https://github.com/NixOS/nixpkgs/commit/375292a2d904c5c1845d5f2f474114d514ad25da) | `` tsid: 1.7.1 -> 1.8.0 ``                                                                                                                                                                    |
| [`bafb6848`](https://github.com/NixOS/nixpkgs/commit/bafb6848e731c8585d33360240b29d3c895d60da) | `` agorakit: pin php version to 8.2 ``                                                                                                                                                        |
| [`15d0312a`](https://github.com/NixOS/nixpkgs/commit/15d0312a8a5d430c148d39a829f24a379b2e187a) | `` icingaweb2: pin php version to 8.3 ``                                                                                                                                                      |
| [`bf92e7b7`](https://github.com/NixOS/nixpkgs/commit/bf92e7b70b1943612ff2b82cceb564835c5abe8a) | `` om4: fix build on GCC 14 ``                                                                                                                                                                |
| [`630a99e2`](https://github.com/NixOS/nixpkgs/commit/630a99e21818b43362dc9173a0e607160781746f) | `` python312Packages.google-genai: 1.6.0 -> 1.8.0 ``                                                                                                                                          |
| [`a3913326`](https://github.com/NixOS/nixpkgs/commit/a3913326f1a3ea21e789789a8d37a7fbcabc51d6) | `` teleport_17: 17.4.0 -> 17.4.1 ``                                                                                                                                                           |
| [`0069573b`](https://github.com/NixOS/nixpkgs/commit/0069573bc4faf8bdd4dcb3c6a5084afdbf4eb721) | `` teleport_16: 16.4.18 -> 16.5.0 ``                                                                                                                                                          |
| [`0a5d47a7`](https://github.com/NixOS/nixpkgs/commit/0a5d47a772479763996e04063aa523474e030f89) | `` ryubing: only link to sndio on linux ``                                                                                                                                                    |
| [`22782bd0`](https://github.com/NixOS/nixpkgs/commit/22782bd04bf84ffedd977660f54576dd4254102b) | `` beam26Packages.elixir-ls: 0.27.1 -> 0.27.2 ``                                                                                                                                              |
| [`81ac8a76`](https://github.com/NixOS/nixpkgs/commit/81ac8a76665fb63a03d78d185a896d1e94d8412b) | `` androidenv: support 5 years of Android APIs with images; test 10 without ``                                                                                                                |
| [`c75818be`](https://github.com/NixOS/nixpkgs/commit/c75818be077516c8ab9f90910ac41e7376a49f17) | `` androidenv: platforms: 35 -> 36; sources: 35 -> 36; build-tools: 35.0.1 -> 36.0.0; cmdline-tools: 17.0 -> 19.0; skiaparser: 6 -> 7; cmake: 3.31.5 -> 3.31.6; emulator: 35.4.8 -> 35.5.8 `` |
| [`f81ada79`](https://github.com/NixOS/nixpkgs/commit/f81ada79e38a834bb068d9eb571663239e03903c) | `` androidenv: emulator: support 35.5.x ``                                                                                                                                                    |
| [`63ebb67f`](https://github.com/NixOS/nixpkgs/commit/63ebb67f9ce1b54a90575f2f54db2cb1701c907c) | `` androidenv: prefer local build for fetching packages ``                                                                                                                                    |
| [`b757ce39`](https://github.com/NixOS/nixpkgs/commit/b757ce39d6b1dfede9a78909c541dd7ee795053f) | `` androidenv: support minPlatformVersion and maxPlatformVersion ``                                                                                                                           |
| [`807356fa`](https://github.com/NixOS/nixpkgs/commit/807356fa6960fa76767ee7b696530cf5c671bd62) | `` androidenv: accept license during tests ``                                                                                                                                                 |
| [`11dce5a2`](https://github.com/NixOS/nixpkgs/commit/11dce5a28d2585442f60fa36c5e37bd1b810a447) | `` doc: clarify how if-supported works ``                                                                                                                                                     |
| [`77af3a07`](https://github.com/NixOS/nixpkgs/commit/77af3a074da879eccdd1fcbf06443197ceaa4d77) | `` androidenv: compose-android-packages: remove null synonym to if-supported ``                                                                                                               |
| [`9569ad4b`](https://github.com/NixOS/nixpkgs/commit/9569ad4b57868f320e90f12471712d720d586a9f) | `` release-notes: add androidenv details to rl-2505 ``                                                                                                                                        |
| [`239551ec`](https://github.com/NixOS/nixpkgs/commit/239551ec836d78bfca067dc32a727e31e82fd251) | `` doc: update androidenv docs ``                                                                                                                                                             |
| [`3c138411`](https://github.com/NixOS/nixpkgs/commit/3c13841124db4c1c29df0680aa02b3cd5f5b5cbf) | `` androidenv: nixfmt ``                                                                                                                                                                      |
| [`a1eefcb9`](https://github.com/NixOS/nixpkgs/commit/a1eefcb9b4fa5aab2b98539de6a9f035ec1d8ae4) | `` androidenv: add recurseIntoAttrs to packages ``                                                                                                                                            |
| [`803aebe8`](https://github.com/NixOS/nixpkgs/commit/803aebe826635862784f99e059a16a3d6cec0def) | `` androidenv: support if-supported for include* options ``                                                                                                                                   |
| [`8e4f036b`](https://github.com/NixOS/nixpkgs/commit/8e4f036bb91f110cda9576a6e7352d2d7f7c32f3) | `` androidenv: mkrepo/fetchrepo: output update script commit object ``                                                                                                                        |
| [`fb25c379`](https://github.com/NixOS/nixpkgs/commit/fb25c379f4c7918b083d3fc8fc720eb2a04fd570) | `` androidenv: simplify updating and track latest ``                                                                                                                                          |
| [`6e751da3`](https://github.com/NixOS/nixpkgs/commit/6e751da348fd6f9ef76f50d4f26d6aeb73c6cba0) | `` snakefmt: relax dependencies ``                                                                                                                                                            |
| [`676df8e7`](https://github.com/NixOS/nixpkgs/commit/676df8e750e2196776e12a6e78eb7cf9d1514a39) | `` snakefmt: 0.10.2 -> 0.11.0 ``                                                                                                                                                              |
| [`4f57c255`](https://github.com/NixOS/nixpkgs/commit/4f57c255accbc637770323f592f137252b3c53fb) | `` nixosTests.unit-php: migrate to runTest ``                                                                                                                                                 |
| [`2986c383`](https://github.com/NixOS/nixpkgs/commit/2986c38363f734064e164f9fa8d9ecdf5e3c1344) | `` pywal16: 3.8.3 -> 3.8.4 ``                                                                                                                                                                 |
| [`374a5699`](https://github.com/NixOS/nixpkgs/commit/374a5699ea7a2db3f9ed86950d98e0840e9f4f65) | `` mpd: 0.23.17 -> 0.24.2 ``                                                                                                                                                                  |
| [`390cc23f`](https://github.com/NixOS/nixpkgs/commit/390cc23f560dc5e551fdf23e8967f8c1295d0519) | `` mapnik: mark darwin platforms as badPlatforms ``                                                                                                                                           |
| [`0f79d664`](https://github.com/NixOS/nixpkgs/commit/0f79d664bacfce0f0b26fc73fc957fe1fa020505) | `` kord: use fetchCargoVendor ``                                                                                                                                                              |
| [`1ac3c175`](https://github.com/NixOS/nixpkgs/commit/1ac3c175a0b3d2de5c69b832db6cd639faac8f24) | `` kile-wl: use fetchCargoVendor ``                                                                                                                                                           |
| [`8821ba20`](https://github.com/NixOS/nixpkgs/commit/8821ba203c13899a8881030101774a6861fba78f) | `` kclvm: use fetchCargoVendor ``                                                                                                                                                             |
| [`1c83e4b1`](https://github.com/NixOS/nixpkgs/commit/1c83e4b1d7e50826e1d266b3570c949591760908) | `` jronnet: use fetchCargoVendor ``                                                                                                                                                           |
| [`efbc27d3`](https://github.com/NixOS/nixpkgs/commit/efbc27d387968f48af5e2f59790d98f21f4f2420) | `` taler-challenger: 0.14.1 -> 0.14.3-unstable-2025-02-17 ``                                                                                                                                  |
| [`fea6e61d`](https://github.com/NixOS/nixpkgs/commit/fea6e61d6b70fc0f062df65fbcce53903e6525cd) | `` taler-sync: 0.14.1 -> 0.14.2-unstable-2025-03-02 ``                                                                                                                                        |
| [`df5d845f`](https://github.com/NixOS/nixpkgs/commit/df5d845f92ce6a5ef35702dc6ed94e61d52869fc) | `` taler-merchant: 0.14.1 -> 0.14.6-unstable-2025-03-02 ``                                                                                                                                    |
| [`e0143a99`](https://github.com/NixOS/nixpkgs/commit/e0143a99712833933e6e37b996f344bf88a6d10b) | `` taler-exchange: 0.14.1 -> 0.14.6-unstable-2025-03-02 ``                                                                                                                                    |
| [`7146a15a`](https://github.com/NixOS/nixpkgs/commit/7146a15a272c4a11eca3e0bdfbcb47e5df314ada) | `` gnunet-gtk: use finalAttrs ``                                                                                                                                                              |
| [`3061b416`](https://github.com/NixOS/nixpkgs/commit/3061b4164b4f5163f39383b42f24e8eeab5d8090) | `` gnunet-gtk: 0.23.1 -> 0.24.0 ``                                                                                                                                                            |
| [`e14744d4`](https://github.com/NixOS/nixpkgs/commit/e14744d4ad2443f29623f12a31a05277c3c64f3b) | `` gnunet: use finalAttrs; remove `with lib;` ``                                                                                                                                              |
| [`c223a40c`](https://github.com/NixOS/nixpkgs/commit/c223a40ccbd5c4bf3a21cbf101398072761f2b04) | `` gnunet: sort dependencies ``                                                                                                                                                               |
| [`dd0eb88b`](https://github.com/NixOS/nixpkgs/commit/dd0eb88bc5ffeb7a720b83cf68d8530a72f9fc30) | `` gnunet: format with nixfmt ``                                                                                                                                                              |
| [`970a3145`](https://github.com/NixOS/nixpkgs/commit/970a31450d1a64112a33509933d550ee45811248) | `` gnunet: 0.23.1 -> 0.24.0 ``                                                                                                                                                                |
| [`8b661bb8`](https://github.com/NixOS/nixpkgs/commit/8b661bb892f892378d4b31fea882af6ca866d787) | `` siesta: 4.1.5 -> 5.2.2 ``                                                                                                                                                                  |
| [`799b7568`](https://github.com/NixOS/nixpkgs/commit/799b7568a42acd4723db7890f595f0fff25eda81) | `` nwg-displays: 0.3.22 -> 0.3.25 ``                                                                                                                                                          |
| [`b7d2e507`](https://github.com/NixOS/nixpkgs/commit/b7d2e507e0762b21b5128c6adb08071124efe6b8) | `` nixosTests.wordpress: migrate to runTest ``                                                                                                                                                |
| [`8de73d96`](https://github.com/NixOS/nixpkgs/commit/8de73d96e2110223f868a8defe83086d0206f62b) | `` netbird: 0.39.1 -> 0.39.2 ``                                                                                                                                                               |
| [`70ea90c7`](https://github.com/NixOS/nixpkgs/commit/70ea90c7fdcf4e5784ec03db54a9c0297fee95e0) | `` roddhjav-apparmor-rules: 0-unstable-2025-03-14 -> 0-unstable-2025-03-28 ``                                                                                                                 |