### PR TITLE
chore(flake/nixpkgs): `f02fddb8` -> `7a2622e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746141548,
-        "narHash": "sha256-IgBWhX7A2oJmZFIrpRuMnw5RAufVnfvOgHWgIdds+hc=",
+        "lastModified": 1746232882,
+        "narHash": "sha256-MHmBH2rS8KkRRdoU/feC/dKbdlMkcNkB5mwkuipVHeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f02fddb8acef29a8b32f10a335d44828d7825b78",
+        "rev": "7a2622e2c0dbad5c4493cb268aba12896e28b008",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`429c338e`](https://github.com/NixOS/nixpkgs/commit/429c338e1585c6f7af1076c3cd3825b2a4a2e1a3) | `` terraform-providers: special case for aws to use go123 ``                               |
| [`a8835c5d`](https://github.com/NixOS/nixpkgs/commit/a8835c5d849a6622a1be05e974761a04d20497e8) | `` intel-media-driver: 24.4.4 -> 25.1.4 ``                                                 |
| [`7c4e6bcf`](https://github.com/NixOS/nixpkgs/commit/7c4e6bcf317100a8efb95764f8b21464b36cd61f) | `` python312Packages.mizani: 0.13.3 -> 0.13.4 ``                                           |
| [`cb9d72cd`](https://github.com/NixOS/nixpkgs/commit/cb9d72cd420d92db89144999679b4e2d3bf84c0d) | `` domination: 1.3.3 -> 1.3.4 ``                                                           |
| [`6dd6b211`](https://github.com/NixOS/nixpkgs/commit/6dd6b211280417d6c983854437ec551dfaab914e) | `` drawpile: switch to qt6 ``                                                              |
| [`554b3ffb`](https://github.com/NixOS/nixpkgs/commit/554b3ffbf1dfa196ae7232c5fa6fc4469d18d992) | `` phpunit: 12.1.3 -> 12.1.4 ``                                                            |
| [`4cad2bd1`](https://github.com/NixOS/nixpkgs/commit/4cad2bd16f02b321290f907c7fdd11575acb0a9f) | `` ISSUE_TEMPLATE: Create option for packages without a Hydra build status (#400751) ``    |
| [`22bf0a21`](https://github.com/NixOS/nixpkgs/commit/22bf0a213faa7d0308fc006447d543cfb71ad12a) | `` flitter: 1.1.1 -> 1.1.3 ``                                                              |
| [`7742cfd0`](https://github.com/NixOS/nixpkgs/commit/7742cfd0633ae6a820e3fa5840fa2f10d547d30c) | `` n2: unstable-2023-10-10 -> unstable-2025-03-14 ``                                       |
| [`1dd65f83`](https://github.com/NixOS/nixpkgs/commit/1dd65f83d3d4504c36416cd79bc117d2a2ea9424) | `` ollama: 0.6.6 -> 0.6.7 ``                                                               |
| [`fc077d0d`](https://github.com/NixOS/nixpkgs/commit/fc077d0d1fa3401d9d65cbca38215e6dddc87135) | `` python3Packages.google-cloud-bigtable: 2.30.0 -> 2.30.1 ``                              |
| [`43e519b0`](https://github.com/NixOS/nixpkgs/commit/43e519b0e0f46b7d8f61bf57c4bbb28f9f9a9d70) | `` skyemu: init at 3.0.0 ``                                                                |
| [`f0936d4e`](https://github.com/NixOS/nixpkgs/commit/f0936d4e975bc1aa05c831c567d968a92b858b8a) | `` {kubernetes,kubectl}: 1.32.3 -> 1.33.0 ``                                               |
| [`14e52aca`](https://github.com/NixOS/nixpkgs/commit/14e52aca5d68be092249fee3b9d5ae8533b05dde) | `` python3Packages.oslo-utils: disable flaky test ``                                       |
| [`2a5e38b0`](https://github.com/NixOS/nixpkgs/commit/2a5e38b022e54ee7e1849a22eb897b048f379c91) | `` kubernetes-helmPlugins.helm-secrets: 4.6.3 -> 4.6.4 ``                                  |
| [`e5ab85fe`](https://github.com/NixOS/nixpkgs/commit/e5ab85feaa5e54e4aa7b583512ab275cbd37dfb9) | `` mullvad-browser: 14.5 -> 14.5.1 ``                                                      |
| [`2c197205`](https://github.com/NixOS/nixpkgs/commit/2c19720539174df9703d1328e20a139e7dacd9d6) | `` tor-browser: 14.5 -> 14.5.1 ``                                                          |
| [`010bb2f8`](https://github.com/NixOS/nixpkgs/commit/010bb2f82772921b140277919611d04cef7ee341) | `` python3Package.parfive: build from source ``                                            |
| [`eb5312b5`](https://github.com/NixOS/nixpkgs/commit/eb5312b58319d7a5041cc2fa6f2c0146168d5e9e) | `` OWNERS: add owners for teleport files ``                                                |
| [`18138189`](https://github.com/NixOS/nixpkgs/commit/18138189b23cda54a59d894824dfb66f160bd26b) | `` nixos/cook-cli: fix missing module-list.nix entry ``                                    |
| [`83df0ca1`](https://github.com/NixOS/nixpkgs/commit/83df0ca14badcc20fa745da208d63815e1bec8cb) | `` wgsl-analyzer: 0.9.8 -> 2025-04-04 ``                                                   |
| [`1044c1da`](https://github.com/NixOS/nixpkgs/commit/1044c1da93e689341e0eba244e7c9d0499fd25d8) | `` linux-libre.scripts: 19746 -> 19769 ``                                                  |
| [`26a0b9db`](https://github.com/NixOS/nixpkgs/commit/26a0b9dbd80f96f8deb1d71612da4b659c1fe2d7) | `` foot: 1.22.2 → 1.22.3 (#403568) ``                                                      |
| [`83247c0d`](https://github.com/NixOS/nixpkgs/commit/83247c0d415ace64066add427179c7e6878cf6b5) | `` .github/labeler.yml: add COSMIC topic ``                                                |
| [`0f3b5ca1`](https://github.com/NixOS/nixpkgs/commit/0f3b5ca11b8f38a59748dda652b5d34af59bdac0) | `` python3Packages.pyeclib: disable flaky memory usage test ``                             |
| [`ef4f4bc8`](https://github.com/NixOS/nixpkgs/commit/ef4f4bc8070c96356769c5b0694cc5be3633cdda) | `` vimPlugins.blink-cmp: 1.1.1 -> 1.2.0 ``                                                 |
| [`4a0173a7`](https://github.com/NixOS/nixpkgs/commit/4a0173a7368905ceb5ebf04d33712039fc127601) | `` vimPlugins.peek-nvim: fix JS build dependency handling ``                               |
| [`7d14fdca`](https://github.com/NixOS/nixpkgs/commit/7d14fdcaf941a142632256e0738a738c4fd07500) | `` python312Packages.ypy-websocket: disable failing test due to unmaintained dependency `` |
| [`07ebfaed`](https://github.com/NixOS/nixpkgs/commit/07ebfaed8f20b86262abae295204aecbca937ef7) | `` cosmic-ext-ctl: 1.4.0 -> 1.5.0 ``                                                       |
| [`9bbd3da1`](https://github.com/NixOS/nixpkgs/commit/9bbd3da168450b778bae816a034a72431086a183) | `` dvdisaster: fix build ``                                                                |
| [`9338d924`](https://github.com/NixOS/nixpkgs/commit/9338d924dbe0c6b93daec3bf435322812fd176fe) | `` lib.meta.availableOn: Return false if pkg parameter is null ``                          |
| [`f25d3d3b`](https://github.com/NixOS/nixpkgs/commit/f25d3d3b6440c1522b704196944864288f322122) | `` comrak: 0.38.0 -> 0.39.0 ``                                                             |
| [`8a8ad47b`](https://github.com/NixOS/nixpkgs/commit/8a8ad47bed7301195c77b0eaa240095871ea04fd) | `` quarto: 1.6.43 -> 1.7.29 ``                                                             |
| [`8e3b725f`](https://github.com/NixOS/nixpkgs/commit/8e3b725f9b983e422644846d4d70a40988814f62) | `` poptracker: fix sdl2-compat compat, unbreak ``                                          |
| [`4afcca67`](https://github.com/NixOS/nixpkgs/commit/4afcca6723fe8edc7fe34d8d6c776d8832c86262) | `` jql: 8.0.5 -> 8.0.6 ``                                                                  |
| [`154f79b2`](https://github.com/NixOS/nixpkgs/commit/154f79b231b33f9dd70291f20753604c35811f63) | `` vimPlugins.kanagawa-paper-nvim: init at 2025-04-27 ``                                   |
| [`894857b7`](https://github.com/NixOS/nixpkgs/commit/894857b781dd68a1f2df789c1c2c348b09dbfe85) | `` nss_latest: 3.110 -> 3.111 ``                                                           |
| [`69a3946c`](https://github.com/NixOS/nixpkgs/commit/69a3946cf441da67b99b7044bffaee226a308c85) | `` kddockwidgets: 2.2.3 -> 2.2.4 ``                                                        |
| [`5981fe33`](https://github.com/NixOS/nixpkgs/commit/5981fe334230bdfce9054d663b49fc46c521fe5e) | `` python312Packages.textual: 3.1.1 -> 3.2.0 ``                                            |
| [`b6d584af`](https://github.com/NixOS/nixpkgs/commit/b6d584af5f0d77ce20e61a9c2e3be2baaa2ef32d) | `` rare-regex: 0.4.3 -> 0.4.4 ``                                                           |
| [`fc98e1a6`](https://github.com/NixOS/nixpkgs/commit/fc98e1a65f539fc14b8003ee870493e749f46ab7) | `` satty: 0.16.0 -> 0.17.0 ``                                                              |
| [`d89230fd`](https://github.com/NixOS/nixpkgs/commit/d89230fd4255e5213b93f37eff81cb0e4ea886b1) | `` pharo: 10.3.1 -> 10.3.4 ``                                                              |
| [`58afaa23`](https://github.com/NixOS/nixpkgs/commit/58afaa233b8a53cc07aa237cbd55847358f158ee) | `` kube-bench: 0.10.5 -> 0.10.6 ``                                                         |
| [`f80fb94d`](https://github.com/NixOS/nixpkgs/commit/f80fb94d1ca8ae99229cb4b4282d508fde4b3403) | `` libmsquic: 2.4.9 -> 2.4.10 ``                                                           |
| [`b9d10774`](https://github.com/NixOS/nixpkgs/commit/b9d10774f2ed3ee81c79238433ffd0e730d3a13c) | `` xh: 0.24.0 -> 0.24.1 ``                                                                 |
| [`e750c1dd`](https://github.com/NixOS/nixpkgs/commit/e750c1dd8ca2548a86f8d0ce943bcdd814ea1171) | `` pulumi-bin: 3.165.0 -> 3.167.0 ``                                                       |
| [`801d3928`](https://github.com/NixOS/nixpkgs/commit/801d3928a76db3a3f7d97cfea7adfd76c37b2e34) | `` bemoji: add MrSom3body as maintainer ``                                                 |
| [`d48ec0c6`](https://github.com/NixOS/nixpkgs/commit/d48ec0c6b7679392f5d1d1ab43aa174c1380f671) | `` bemoji: 0.4.0 -> 0.4.0-unstable-2024-04-28 ``                                           |
| [`e13ad2c9`](https://github.com/NixOS/nixpkgs/commit/e13ad2c92a3f2c70d59bd76a3f455916dbb8208f) | `` golden-cheetah: 3.7-DEV2408 -> 3.7 ``                                                   |
| [`f7a1a095`](https://github.com/NixOS/nixpkgs/commit/f7a1a09564ab8499a966bd0ded9225d85f5d9603) | `` python312Packages.gpu-rir: init at 0-unstable-2025-01-20 ``                             |
| [`a4d6a7e3`](https://github.com/NixOS/nixpkgs/commit/a4d6a7e3633c649b374817472b5a29da7b0ab9c9) | `` encrypted-dns-server: 0.9.16 -> 0.9.17 ``                                               |
| [`c4419e28`](https://github.com/NixOS/nixpkgs/commit/c4419e283bd74b956c3f5dd7229f9eda208a93b7) | `` goto: init at 2.1.0-unstable-2020-11-15 ``                                              |
| [`b90b9c69`](https://github.com/NixOS/nixpkgs/commit/b90b9c6988e7de50ad6d745c316ea50b01d264bc) | `` functiontrace-server: 0.8.3 -> 0.8.4 ``                                                 |
| [`c27f3bc1`](https://github.com/NixOS/nixpkgs/commit/c27f3bc1a625b4b30cd2930e5d731be8a13768d5) | `` python312Packages.fireworks-ai: 0.15.12 -> 0.15.13 ``                                   |
| [`a1df13e2`](https://github.com/NixOS/nixpkgs/commit/a1df13e2306803132f54511769412f746f1a9f7a) | `` python3Packages.pytest-postgresql-darwin: disable checkPhase on darwin ``               |
| [`653b0cea`](https://github.com/NixOS/nixpkgs/commit/653b0ceac942d5db57db41072b5e801a2bd15ea5) | `` unleash-client-haskell/unleash-client-haskell-core: remove maintainer ``                |
| [`9849e6fc`](https://github.com/NixOS/nixpkgs/commit/9849e6fc7660e70cd1eae7769fa5ee9408bc78d4) | `` sherlock: fix build ``                                                                  |
| [`15c7d2f6`](https://github.com/NixOS/nixpkgs/commit/15c7d2f622bcc38b02df7aa1933608a7a96305bc) | `` vimPlugins.oil-git-status-nvim: init at 2025-04-03 ``                                   |
| [`a1cb628c`](https://github.com/NixOS/nixpkgs/commit/a1cb628cce21e6780a61171446a6191d82cf92bd) | `` zvbi: fix cross to musl ``                                                              |
| [`bf2d0fcd`](https://github.com/NixOS/nixpkgs/commit/bf2d0fcde3a3dd6caf38ba2a763bc5f879a3f756) | `` python312Packages.xeddsa: init at 1.1.0 ``                                              |
| [`be3cbddd`](https://github.com/NixOS/nixpkgs/commit/be3cbddd940b03954a0e35b6397bf3064da68a16) | `` libxeddsa: init at 2.0.0 ``                                                             |
| [`73094d81`](https://github.com/NixOS/nixpkgs/commit/73094d81b991391b97ff7a42068779204bdfc172) | `` kodi.packages.bluetooth-manager: init at 1.0.4 ``                                       |
| [`bb4d872f`](https://github.com/NixOS/nixpkgs/commit/bb4d872f258ea47c68c52487135e7f8a5d70c29a) | `` tidal-hifi: 5.18.2 -> 5.19.0 ``                                                         |
| [`da0fd3c8`](https://github.com/NixOS/nixpkgs/commit/da0fd3c8e49e02dc3524eebc05b65cca5ea5ead6) | `` aligator: exclude another failing test on x86_64-darwin ``                              |
| [`5d364c5e`](https://github.com/NixOS/nixpkgs/commit/5d364c5ed243fab6ea6c78dc8391fc6db4194479) | `` maintainers: add bmrips ``                                                              |
| [`b9b9c632`](https://github.com/NixOS/nixpkgs/commit/b9b9c6328943ec1cc6de3513758067d08d1f3b19) | `` all-the-package-names: 2.0.2137 -> 2.0.2146 ``                                          |
| [`ebf20b29`](https://github.com/NixOS/nixpkgs/commit/ebf20b295d847705963a95ae96e92f1c963b2006) | `` tfsec: 1.28.13 -> 1.28.14 ``                                                            |
| [`36b61c8e`](https://github.com/NixOS/nixpkgs/commit/36b61c8ecc8b11fb1b02da1bef8983b3bb64fedd) | `` templ: 0.3.857 -> 0.3.865 ``                                                            |
| [`cacac1fd`](https://github.com/NixOS/nixpkgs/commit/cacac1fde031364e322d06bae341c82b75bf4fb7) | `` linux_5_4: 5.4.292 -> 5.4.293 ``                                                        |
| [`d6d2a5fb`](https://github.com/NixOS/nixpkgs/commit/d6d2a5fb9c21e0ce04ebd3ee81ffe49997a6679a) | `` linux_5_10: 5.10.236 -> 5.10.237 ``                                                     |
| [`a51c3154`](https://github.com/NixOS/nixpkgs/commit/a51c31546f15d7ea2a02c0f0ed28658a5fae536c) | `` linux_5_15: 5.15.180 -> 5.15.181 ``                                                     |
| [`065ab048`](https://github.com/NixOS/nixpkgs/commit/065ab048abff7579babb90f15942b59d3bb5a9f4) | `` linux_6_1: 6.1.135 -> 6.1.136 ``                                                        |
| [`231f3b88`](https://github.com/NixOS/nixpkgs/commit/231f3b88b59585196cb03db2841fef566842d12b) | `` linux_6_6: 6.6.88 -> 6.6.89 ``                                                          |
| [`41351bf0`](https://github.com/NixOS/nixpkgs/commit/41351bf070c2db32b6461ae165ab07c670749ddc) | `` linux_6_12: 6.12.25 -> 6.12.26 ``                                                       |
| [`556933f1`](https://github.com/NixOS/nixpkgs/commit/556933f144456d4ae5fad894ab61f3b93ef91f9c) | `` linux_6_14: 6.14.4 -> 6.14.5 ``                                                         |
| [`6071c86c`](https://github.com/NixOS/nixpkgs/commit/6071c86c00814fb60f37ca7eb5268be629633016) | `` tzf-rs: init at 1.0.0 ``                                                                |
| [`577e26e8`](https://github.com/NixOS/nixpkgs/commit/577e26e8d0f4146abf3922f20a898ea9e8e99a49) | `` prometheus-pihole-exporter: 1.0.1 -> 1.1.0 ``                                           |
| [`bc9db2af`](https://github.com/NixOS/nixpkgs/commit/bc9db2af2e4928a50d9fd3c8b3215b38e27f5f9d) | `` python312Packages.posthog: 3.25.0 -> 4.0.1 ``                                           |
| [`c5ca6b20`](https://github.com/NixOS/nixpkgs/commit/c5ca6b2071450f1734fa5049dfe8ed65dc1ac93f) | `` anubis: 1.16.0 -> 1.17.1 ``                                                             |
| [`243e0cb0`](https://github.com/NixOS/nixpkgs/commit/243e0cb0b9b6b3dcf63d04178f4e2e8053a59e44) | `` pytr: 0.4.1 -> 0.4.2 ``                                                                 |
| [`4cd11fd5`](https://github.com/NixOS/nixpkgs/commit/4cd11fd5230261497d946a32c9f04af6b6d824e7) | `` lug-helper: 3.7 -> 3.8 ``                                                               |
| [`d10d917f`](https://github.com/NixOS/nixpkgs/commit/d10d917f07cf79899384dd1743a37b290f20f81a) | `` wapiti: skip failing tests on darwin ``                                                 |
| [`06458578`](https://github.com/NixOS/nixpkgs/commit/06458578441016b3573f496afacf213872966494) | `` sbom2dot: 0.3.1 -> 0.3.2 ``                                                             |
| [`36123f13`](https://github.com/NixOS/nixpkgs/commit/36123f13aed7ffaf518ea626b6389774040bc616) | `` python312Packages.sbom2dot: 0.3.1 -> 0.3.2 ``                                           |
| [`83946015`](https://github.com/NixOS/nixpkgs/commit/83946015011b091fb13cd440cec73e35ca255fbb) | `` ugrep: 7.3.0 -> 7.4.2 ``                                                                |
| [`0414297e`](https://github.com/NixOS/nixpkgs/commit/0414297e7437aade746c3a726c9007fd572ec7db) | `` cargo-tally: 1.0.62 -> 1.0.63 ``                                                        |
| [`f3cdba9c`](https://github.com/NixOS/nixpkgs/commit/f3cdba9ccd806d11b52b47c8300e3d7487538f03) | `` eza: 0.21.2 -> 0.21.3 ``                                                                |
| [`50c4e9b2`](https://github.com/NixOS/nixpkgs/commit/50c4e9b2e0957b7a0e5afe389e416bce042b5871) | `` unblob: 25.1.8 -> 25.4.14 ``                                                            |
| [`a738b32c`](https://github.com/NixOS/nixpkgs/commit/a738b32c8f06f0175a43d1d2b7225cab3672851f) | `` dialect: fix cross compilation ``                                                       |
| [`ebc65ddc`](https://github.com/NixOS/nixpkgs/commit/ebc65ddcebc61bed6df28a0c1e10defca51fe47d) | `` python312Packages.ihm: 2.4 -> 2.5 ``                                                    |
| [`2b7ee45a`](https://github.com/NixOS/nixpkgs/commit/2b7ee45ad787e53040dced8ccba5bbbe7d22632e) | `` python312Packages.wagtail-modeladmin: 2.1.0 -> 2.2.0 ``                                 |
| [`2375cc01`](https://github.com/NixOS/nixpkgs/commit/2375cc015c9c2d5dfaff876d063cd9218ae89a84) | `` ocamlPackages.dune_3: 3.18.1 -> 3.18.2 ``                                               |
| [`cff26cf8`](https://github.com/NixOS/nixpkgs/commit/cff26cf833ce8ca041605d9cbb4dafe69dfa8b23) | `` python312Packages.diffsync: 2.0.1 -> 2.1.0 ``                                           |
| [`fc49a982`](https://github.com/NixOS/nixpkgs/commit/fc49a982ea8b9ba8bb47e8785f5fb1b5d030f52b) | `` gosmee: 0.24.0 -> 0.25.0 ``                                                             |
| [`d5c57bdc`](https://github.com/NixOS/nixpkgs/commit/d5c57bdcd017bb92032f62ad4b81e10881296095) | `` ignite-cli: 28.9.0 -> 28.10.0 ``                                                        |
| [`7edf8123`](https://github.com/NixOS/nixpkgs/commit/7edf81231cc101ce7139de37bfe9ee601076891b) | `` clusterctl: 1.10.0 -> 1.10.1 ``                                                         |